### PR TITLE
Changed nape.shape.Polygon to nape.shape.Shape to Circle

### DIFF
--- a/plugins/nape/runtime/src/ceramic/VisualNapePhysics.hx
+++ b/plugins/nape/runtime/src/ceramic/VisualNapePhysics.hx
@@ -10,7 +10,7 @@ class VisualNapePhysics extends Entity {
     public var body:nape.phys.Body = null;
 
     public function new(
-        bodyType:NapePhysicsBodyType, ?shape:nape.shape.Polygon, ?material:nape.phys.Material,
+        bodyType:NapePhysicsBodyType, ?shape:nape.shape.Shape, ?material:nape.phys.Material,
         x:Float, y:Float, width:Float, height:Float, rotation:Float
         ) {
 

--- a/runtime/src/ceramic/Visual.hx
+++ b/runtime/src/ceramic/Visual.hx
@@ -883,7 +883,7 @@ class Visual extends #if ceramic_visual_base VisualBase #else Entity #end #if pl
     public function initNapePhysics(
         type:ceramic.NapePhysicsBodyType,
         ?space:nape.space.Space,
-        ?shape:nape.shape.Polygon,
+        ?shape:nape.shape.Shape,
         ?material:nape.phys.Material
     ):VisualNapePhysics {
 


### PR DESCRIPTION
Hi!

What do you think about allowing different nape shapes and not only Polygons?

To be used like this:

`    override function create() {

        var space = app.nape.space;
        space.gravity.y = 1000;

        var arc:Arc = new Arc();
        arc.color = Color.ORANGE;
        arc.pos(200, 200);
        arc.angle = 360;
        arc.sides = 100;
        arc.borderPosition = BorderPosition.INSIDE;
        arc.thickness = 120;
        
        var circleShape:Circle = new Circle(64);
        arc.initNapePhysics(DYNAMIC, space, circleShape);

        var arc2:Arc = new Arc();
        arc2.color = Color.YELLOW;
        arc2.pos(230, 300);
        arc2.angle = 360;
        arc2.sides = 100;
        arc2.borderPosition = BorderPosition.INSIDE;
        arc2.thickness = 120;
        
        var circleShape2:Circle = new Circle(64);
        arc2.initNapePhysics(STATIC, space, circleShape2);

    }`