### PR TITLE
Nape bodies are not removed from the nape space when being destroyed

### DIFF
--- a/plugins/nape/runtime/src/ceramic/VisualNapePhysics.hx
+++ b/plugins/nape/runtime/src/ceramic/VisualNapePhysics.hx
@@ -50,7 +50,6 @@ class VisualNapePhysics extends Entity {
 
         super.destroy();
             
-        body.constraints.foreach(c -> c.active = false);
         body.space = null;
 
         if (visual != null) {

--- a/plugins/nape/runtime/src/ceramic/VisualNapePhysics.hx
+++ b/plugins/nape/runtime/src/ceramic/VisualNapePhysics.hx
@@ -49,6 +49,9 @@ class VisualNapePhysics extends Entity {
     override function destroy() {
 
         super.destroy();
+            
+        body.constraints.foreach((c) -> c.active = false);
+        body.space = null;
 
         if (visual != null) {
             if (visual.nape == this) {

--- a/plugins/nape/runtime/src/ceramic/VisualNapePhysics.hx
+++ b/plugins/nape/runtime/src/ceramic/VisualNapePhysics.hx
@@ -50,7 +50,7 @@ class VisualNapePhysics extends Entity {
 
         super.destroy();
             
-        body.constraints.foreach((c) -> c.active = false);
+        body.constraints.foreach(c -> c.active = false);
         body.space = null;
 
         if (visual != null) {


### PR DESCRIPTION
Hi!

Only the visual part gets removed if I call destroy() on a Visual instance that I have initNapePhysics() on.
So the nape physics objects was still around even thought I destroyed() them.

So I added some code to remove the nape body from space.
I don't know if this i the best place for this code though, but it seems to work without crashing. :)

