### PR TITLE
Allow relative/subfolder font paths

### DIFF
--- a/runtime/src/ceramic/BitmapFont.hx
+++ b/runtime/src/ceramic/BitmapFont.hx
@@ -3,7 +3,7 @@ package ceramic;
 // Substantial portion taken from luxe (https://github.com/underscorediscovery/luxe/blob/4c891772f54b4769c72515146bedde9206a7b986/phoenix/BitmapFont.hx)
 
 using ceramic.Extensions;
-import ceramic.Path;
+using ceramic.Path;
 
 class BitmapFont extends Entity {
 

--- a/runtime/src/ceramic/BitmapFont.hx
+++ b/runtime/src/ceramic/BitmapFont.hx
@@ -113,7 +113,7 @@ class BitmapFont extends Entity {
 
         for (pageInfo in fontData.pages) {
             var pageFile = pageInfo.file;
-            if (fontData.path != '') {
+            if (fontData.path != '.') {
                 pageFile = Path.join([fontData.path, pageInfo.file]);
             }
 

--- a/runtime/src/ceramic/BitmapFont.hx
+++ b/runtime/src/ceramic/BitmapFont.hx
@@ -3,6 +3,7 @@ package ceramic;
 // Substantial portion taken from luxe (https://github.com/underscorediscovery/luxe/blob/4c891772f54b4769c72515146bedde9206a7b986/phoenix/BitmapFont.hx)
 
 using ceramic.Extensions;
+import ceramic.Path;
 
 class BitmapFont extends Entity {
 
@@ -113,7 +114,7 @@ class BitmapFont extends Entity {
         for (pageInfo in fontData.pages) {
             var pageFile = pageInfo.file;
             if (fontData.path != '') {
-                pageFile = '${fontData.path}/${pageInfo.file}';
+                pageFile = Path.join([fontData.path, pageInfo.file]);
             }
 
             var texture = pages.get(pageFile);

--- a/runtime/src/ceramic/BitmapFont.hx
+++ b/runtime/src/ceramic/BitmapFont.hx
@@ -111,7 +111,13 @@ class BitmapFont extends Entity {
         }
 
         for (pageInfo in fontData.pages) {
-            var texture = pages.get(pageInfo.file);
+            var pageFile = pageInfo.file;
+            if (fontData.path != '') {
+                pageFile = '${fontData.path}/${pageInfo.file}';
+            }
+
+            var texture = pages.get(pageFile);
+            
             if (texture == null) {
                 throw 'BitmapFont: missing texture for file ' + pageInfo.file;
             }

--- a/runtime/src/ceramic/BitmapFontParser.hx
+++ b/runtime/src/ceramic/BitmapFontParser.hx
@@ -24,7 +24,7 @@ class BitmapFontParser {
         }
 
         var info:BitmapFontData = {
-            path: '',
+            path: '.',
             face: null,
             chars: new IntMap(),
             distanceField: null,

--- a/runtime/src/ceramic/BitmapFontParser.hx
+++ b/runtime/src/ceramic/BitmapFontParser.hx
@@ -24,6 +24,7 @@ class BitmapFontParser {
         }
 
         var info:BitmapFontData = {
+            path: '',
             face: null,
             chars: new IntMap(),
             distanceField: null,

--- a/runtime/src/ceramic/FontAsset.hx
+++ b/runtime/src/ceramic/FontAsset.hx
@@ -1,6 +1,7 @@
 package ceramic;
 
 import ceramic.Shortcuts.*;
+import ceramic.Path;
 
 class FontAsset extends Asset {
 
@@ -54,10 +55,6 @@ class FontAsset extends Asset {
 
         log.info('Load font $path');
 
-        var mainFontPathInfo = Assets.decodePath(path);
-        var relativeFontPath = mainFontPathInfo.name.split('/');
-        relativeFontPath.pop(); // remove file name
-        var relativeFontPath = relativeFontPath.join('/');
 
         // Use runtime assets if provided
         assets.runtimeAssets = runtimeAssets;
@@ -68,6 +65,7 @@ class FontAsset extends Asset {
         assets.addAsset(asset);
         assets.onceComplete(this, function(success) {
 
+            var relativeFontPath = Path.directory(path);
             var text = asset.text;
 
             if (text != null) {
@@ -84,7 +82,7 @@ class FontAsset extends Asset {
 
                         var pageFile = page.file;
                         if (relativeFontPath != '') {
-                            pageFile = '${relativeFontPath}/${pageFile}';
+                            pageFile = Path.join([relativeFontPath, pageFile]);
                         }
 
                         var pathInfo = Assets.decodePath(pageFile);

--- a/runtime/src/ceramic/FontAsset.hx
+++ b/runtime/src/ceramic/FontAsset.hx
@@ -1,7 +1,8 @@
 package ceramic;
 
 import ceramic.Shortcuts.*;
-import ceramic.Path;
+
+using ceramic.Path;
 
 class FontAsset extends Asset {
 
@@ -65,8 +66,9 @@ class FontAsset extends Asset {
         assets.addAsset(asset);
         assets.onceComplete(this, function(success) {
 
-            var relativeFontPath = Path.directory(path);
             var text = asset.text;
+            var relativeFontPath = Path.directory(path);
+            if (relativeFontPath == '') relativeFontPath = '.';
 
             if (text != null) {
 
@@ -81,7 +83,7 @@ class FontAsset extends Asset {
                     for (page in fontData.pages) {
 
                         var pageFile = page.file;
-                        if (relativeFontPath != '.') {
+                        if (relativeFontPath != '') {
                             pageFile = Path.join([relativeFontPath, pageFile]);
                         }
 

--- a/runtime/src/ceramic/FontAsset.hx
+++ b/runtime/src/ceramic/FontAsset.hx
@@ -54,6 +54,11 @@ class FontAsset extends Asset {
 
         log.info('Load font $path');
 
+        var mainFontPathInfo = Assets.decodePath(path);
+        var relativeFontPath = mainFontPathInfo.name.split('/');
+        relativeFontPath.pop(); // remove file name
+        var relativeFontPath = relativeFontPath.join('/');
+
         // Use runtime assets if provided
         assets.runtimeAssets = runtimeAssets;
 
@@ -69,6 +74,7 @@ class FontAsset extends Asset {
 
                 try {
                     fontData = BitmapFontParser.parse(text);
+                    fontData.path = relativeFontPath;
 
                     // Load pages
                     var pages = new Map();
@@ -76,7 +82,12 @@ class FontAsset extends Asset {
 
                     for (page in fontData.pages) {
 
-                        var pathInfo = Assets.decodePath(page.file);
+                        var pageFile = page.file;
+                        if (relativeFontPath != '') {
+                            pageFile = '${relativeFontPath}/${pageFile}';
+                        }
+
+                        var pathInfo = Assets.decodePath(pageFile);
                         var asset = new ImageAsset(pathInfo.name);
 
                         // Because it is handled at font level

--- a/runtime/src/ceramic/FontAsset.hx
+++ b/runtime/src/ceramic/FontAsset.hx
@@ -81,7 +81,7 @@ class FontAsset extends Asset {
                     for (page in fontData.pages) {
 
                         var pageFile = page.file;
-                        if (relativeFontPath != '') {
+                        if (relativeFontPath != '.') {
                             pageFile = Path.join([relativeFontPath, pageFile]);
                         }
 


### PR DESCRIPTION
Adds path info to Bitfont in order to load images relative.
Generated Bitfont files have their pngs, relative to the .fnt file.
If we would place a font in `/assets/fonts` it would currently try to resolve the image from `/assets` instead of `/assets/fonts`.

This pr resolves that issue.