### PR TITLE
Updating warning text in FileWatcher when using js

### DIFF
--- a/runtime/src/ceramic/FileWatcher.hx
+++ b/runtime/src/ceramic/FileWatcher.hx
@@ -68,7 +68,7 @@ class FileWatcher extends Entity #if interpret implements interpret.Watcher #end
     public function watch(path:String, onUpdate:String->Void):Void->Void {
 
         if (!canWatch()) {
-            trace('[warning] Cannot watch file at path $path with StandardWatcher on this target');
+            trace('[warning] Cannot watch file at path $path with FileWatcher on this target. Have you added electron to the plugins in your ceramic.yml?');
             return function() {};
         }
 


### PR DESCRIPTION
Trying to make the warning hint to use the electron plugin in ceramic.yml if `canWatch` is false.
Also updated to text to be about  FileWatcher.