### PR TITLE
Setting texture wrap mode

### DIFF
--- a/plugins/clay/runtime/src/backend/Textures.hx
+++ b/plugins/clay/runtime/src/backend/Textures.hx
@@ -293,6 +293,32 @@ class Textures implements spec.Textures {
 
     }
 
+    inline public function setTextureWrapS(texture: Texture, wrap: ceramic.TextureWrap): Void {
+            
+            switch (wrap) {
+                case CLAMP_TO_EDGE:
+                    (texture: clay.graphics.Texture).wrapS = CLAMP_TO_EDGE;
+                case REPEAT:
+                    (texture: clay.graphics.Texture).wrapS = REPEAT;
+                case MIRRORED_REPEAT:
+                    (texture: clay.graphics.Texture).wrapS = MIRRORED_REPEAT;
+            }
+    
+    }
+
+    inline public function setTextureWrapT(texture: Texture, wrap: ceramic.TextureWrap): Void {
+            
+            switch (wrap) {
+                case CLAMP_TO_EDGE:
+                    (texture: clay.graphics.Texture).wrapT = CLAMP_TO_EDGE;
+                case REPEAT:
+                    (texture: clay.graphics.Texture).wrapT = REPEAT;
+                case MIRRORED_REPEAT:
+                    (texture: clay.graphics.Texture).wrapT = MIRRORED_REPEAT;
+            }
+    
+    }
+
     static var _maxTexturesByBatch:Int = -1;
 
     #if cpp

--- a/plugins/headless/runtime/src/backend/Textures.hx
+++ b/plugins/headless/runtime/src/backend/Textures.hx
@@ -93,6 +93,18 @@ class Textures implements spec.Textures {
 
     }
 
+    inline public function setTextureWrapS(texture: Texture, wrap: ceramic.TextureWrap): Void {
+            
+        //
+
+    }
+
+    inline public function setTextureWrapT(texture: Texture, wrap: ceramic.TextureWrap): Void {
+        
+        //
+
+    }
+
     public function maxTexturesByBatch():Int {
 
         return 1;

--- a/plugins/unity/runtime/src/backend/Textures.hx
+++ b/plugins/unity/runtime/src/backend/Textures.hx
@@ -313,6 +313,18 @@ class Textures implements spec.Textures {
 
     }
 
+    inline public function setTextureWrapS(texture: Texture, wrap: ceramic.TextureWrap): Void {
+            
+        // Not implemented yet
+
+    }
+
+    inline public function setTextureWrapT(texture: Texture, wrap: ceramic.TextureWrap): Void {
+        
+        // Not implemented yet
+
+    }
+
     inline public function supportsHotReloadPath():Bool {
 
         return false;

--- a/runtime/src/ceramic/Texture.hx
+++ b/runtime/src/ceramic/Texture.hx
@@ -88,6 +88,40 @@ class Texture extends Entity {
         return filter;
     }
 
+    /**
+     * Horizontal texture wrap mode
+     */
+    public var wrapS(default,set):TextureWrap = CLAMP_TO_EDGE;
+    function set_wrapS(wrapS:TextureWrap):TextureWrap {
+        if (this.wrapS == wrapS) return wrapS;
+        this.wrapS = wrapS;
+        app.backend.textures.setTextureWrapS(backendItem, wrapS);
+        return wrapS;
+    }
+
+    /**
+     * Vertical texture wrapping mode
+     */
+    public var wrapT(default,set):TextureWrap = CLAMP_TO_EDGE;
+    function set_wrapT(wrapT:TextureWrap):TextureWrap {
+        if (this.wrapT == wrapT) return wrapT;
+        this.wrapT = wrapT;
+        app.backend.textures.setTextureWrapT(backendItem, wrapT);
+        return wrapT;
+    }
+
+    /**
+     * Shorthand for setting both wrapS and wrapT at the same time.
+     * Possible values: `CLAMP_TO_EDGE`, `REPEAT`, `MIRRORED_REPEAT`
+     * @param wrapS horizontal wrap mode
+     * @param wrapT vertical wrap mode
+     */
+    public function setWrap(wrapS:TextureWrap, ?wrapT:TextureWrap):Void {
+        set_wrapS(wrapS);
+        if(wrapT != null)
+            set_wrapT(wrapT);
+    }
+
     public var backendItem:backend.Texture;
 
     public var asset:ImageAsset = null;

--- a/runtime/src/ceramic/TextureWrap.hx
+++ b/runtime/src/ceramic/TextureWrap.hx
@@ -1,0 +1,11 @@
+package ceramic;
+
+enum TextureWrap {
+
+    CLAMP_TO_EDGE;
+
+    REPEAT;
+
+    MIRRORED_REPEAT;
+
+}

--- a/runtime/src/spec/Textures.hx
+++ b/runtime/src/spec/Textures.hx
@@ -36,6 +36,10 @@ interface Textures {
 
     function setTextureFilter(texture:Texture, filter:ceramic.TextureFilter):Void;
 
+    function setTextureWrapS(texture: Texture, wrap: ceramic.TextureWrap):Void;
+
+    function setTextureWrapT(texture: Texture, wrap: ceramic.TextureWrap):Void;
+
     function createRenderTarget(width:Int, height:Int, depth:Bool, stencil:Bool, antialiasing:Int):Texture;
 
     /**


### PR DESCRIPTION
Support for setting texture wrap without the need to access and cast the backend objects (similar to texture filter).

Created functions for setting wrapS/wrapT and a shorthand for both in ceramic.

Created required functions in plugins: clay, unity and headless.