### PR TITLE
[ldtk] Set the def field in LdtkFieldInstance

### DIFF
--- a/plugins/ldtk/runtime/src/ceramic/LdtkData.hx
+++ b/plugins/ldtk/runtime/src/ceramic/LdtkData.hx
@@ -939,6 +939,11 @@ class LdtkEntityDefinition {
      */
     public var tags:Array<String>;
 
+    /**
+     * An array of field definitions that belong to this entity definition
+     */
+    public var fieldDefs:Array<LdtkFieldDefinition>;
+
     public function new(?defs:LdtkDefinitions, ?json:DynamicAccess<Dynamic>) {
 
         this.defs = defs;
@@ -961,6 +966,10 @@ class LdtkEntityDefinition {
                 tileset = defs.ldtkData.findTilesetDef(Std.int(json.get('tilesetId')));
             uid = Std.int(json.get('uid'));
             tags = LdtkDataHelpers.toStringArray(json.get('tags'));
+            var fieldDefsJson:Array<Dynamic> = json.get('fieldDefs');
+            fieldDefs = fieldDefsJson != null ? [for (i in 0...fieldDefsJson.length) {
+                new LdtkFieldDefinition(defs, fieldDefsJson[i]);
+            }] : [];
         }
 
     }
@@ -1011,6 +1020,21 @@ class LdtkEntityDefinition {
             return res;
         }
         return LdtkDataHelpers.HIDDEN_VALUE;
+
+    }
+
+    public function fieldDef(identifier:String):LdtkFieldDefinition {
+
+        if (this.fieldDefs != null) {
+            for (i in 0...this.fieldDefs.length) {
+                var fieldDef = this.fieldDefs[i];
+                if (fieldDef.identifier == identifier) {
+                    return fieldDef;
+                }
+            }
+        }
+
+        return null;
 
     }
 
@@ -2792,7 +2816,9 @@ class LdtkFieldInstance {
      */
     public var tile:LdtkTilesetRectangle;
 
-    public function new(?ldtkData:LdtkData, ?ldtkWorld:LdtkWorld, ?json:DynamicAccess<Dynamic>) {
+    public function new(?ldtkData:LdtkData, ?ldtkWorld:LdtkWorld, ?json:DynamicAccess<Dynamic>, ?def:LdtkFieldDefinition) {
+
+        this.def = def;
 
         if (json != null) {
             var defUid:Int = Std.int(json.get('defUid'));
@@ -3199,7 +3225,9 @@ class LdtkEntityInstance {
 
             var fieldInstancesJson:Array<Dynamic> = json.get('fieldInstances');
             fieldInstances = fieldInstancesJson != null ? [for (i in 0...fieldInstancesJson.length) {
-                new LdtkFieldInstance(ldtkData, ldtkWorld, fieldInstancesJson[i]);
+                var fieldInstanceJson:haxe.DynamicAccess<Dynamic> = fieldInstancesJson[i];
+                var identifier = fieldInstanceJson.get('__identifier');
+                new LdtkFieldInstance(ldtkData, ldtkWorld, fieldInstanceJson, def.fieldDef(identifier));
             }] : [];
         }
 


### PR DESCRIPTION
I noticed that all `LdtkFieldInstance`s return null identifiers. Turns out that's because the `def` class field is never set. This PR fixes that. Let me know if the fix looks good or needs some tweaking :)


Tracing the field instances of entities from the `ceramic-samples/ldtk-level`.

Before the change:
```
-- Field instances of entity "Item" --
field: LdtkFieldInstance(identifier=null value=Gold tile=null), field.def: null
field: LdtkFieldInstance(identifier=null value=0 tile=null), field.def: null
field: LdtkFieldInstance(identifier=null value=100 tile=null), field.def: null
-- Field instances of entity "Item" --
field: LdtkFieldInstance(identifier=null value=Healing_potion tile=null), field.def: null
field: LdtkFieldInstance(identifier=null value=0 tile=null), field.def: null
field: LdtkFieldInstance(identifier=null value=1 tile=null), field.def: null
-- Field instances of entity "Player" --
field: LdtkFieldInstance(identifier=null value=[Ammo,Bow] tile=null), field.def: null
field: LdtkFieldInstance(identifier=null value=10 tile=null), field.def: null
-- Field instances of entity "Ladder" --
-- Field instances of entity "Item" --
field: LdtkFieldInstance(identifier=null value=Ammo tile=null), field.def: null
field: LdtkFieldInstance(identifier=null value=0 tile=null), field.def: null
field: LdtkFieldInstance(identifier=null value=5 tile=null), field.def: null
```

After the change:
```
-- Field instances of entity "Item" --
field: LdtkFieldInstance(identifier=type value=Gold tile=null), field.def: LdtkFieldDefinition(type=LocalEnum.ItemType identifier=type uid=76 isArray=false)
field: LdtkFieldInstance(identifier=price value=0 tile=null), field.def: LdtkFieldDefinition(type=Int identifier=price uid=93 isArray=false)
field: LdtkFieldInstance(identifier=count value=100 tile=null), field.def: LdtkFieldDefinition(type=Int identifier=count uid=139 isArray=false)
-- Field instances of entity "Item" --
field: LdtkFieldInstance(identifier=type value=Healing_potion tile=null), field.def: LdtkFieldDefinition(type=LocalEnum.ItemType identifier=type uid=76 isArray=false)
field: LdtkFieldInstance(identifier=price value=0 tile=null), field.def: LdtkFieldDefinition(type=Int identifier=price uid=93 isArray=false)
field: LdtkFieldInstance(identifier=count value=1 tile=null), field.def: LdtkFieldDefinition(type=Int identifier=count uid=139 isArray=false)
-- Field instances of entity "Player" --
field: LdtkFieldInstance(identifier=inventory value=[Ammo,Bow] tile=null), field.def: LdtkFieldDefinition(type=Array<LocalEnum.ItemType> identifier=inventory uid=91 isArray=true)
field: LdtkFieldInstance(identifier=HP value=10 tile=null), field.def: LdtkFieldDefinition(type=Int identifier=HP uid=92 isArray=false)
-- Field instances of entity "Ladder" --
-- Field instances of entity "Item" --
field: LdtkFieldInstance(identifier=type value=Ammo tile=null), field.def: LdtkFieldDefinition(type=LocalEnum.ItemType identifier=type uid=76 isArray=false)
```