### PR TITLE
[ldtk] Support pixel offsets in gridTiles and autoLayerTiles

### DIFF
--- a/plugins/tilemap/runtime/src/ceramic/TilemapLayer.hx
+++ b/plugins/tilemap/runtime/src/ceramic/TilemapLayer.hx
@@ -315,9 +315,13 @@ class TilemapLayer extends Visual {
             if (layerData.visible) {
                 var tiles = layerData.computedTiles;
                 var tilesAlpha = layerData.computedTilesAlpha;
+                var tilesOffsetX = layerData.computedTilesOffsetX;
+                var tilesOffsetY = layerData.computedTilesOffsetY;
                 if (tiles == null) {
                     tiles = layerData.tiles;
                     tilesAlpha = layerData.tilesAlpha;
+                    tilesOffsetX = layerData.tilesOffsetX;
+                    tilesOffsetY = layerData.tilesOffsetY;
                 }
                 if (tiles != null) {
 
@@ -383,7 +387,15 @@ class TilemapLayer extends Visual {
                                     }
 
                                     var tileLeft = column * tileset.tileWidth;
+                                    if (tilesOffsetX != null) {
+                                        tileLeft += tilesOffsetX.unsafeGet(t);
+                                    }
+
                                     var tileTop = row * tileset.tileWidth;
+                                    if (tilesOffsetY != null) {
+                                        tileTop += tilesOffsetY.unsafeGet(t);
+                                    }
+
                                     var tileWidth = tileset.tileWidth;
                                     var tileHeight = tileset.tileHeight;
 

--- a/plugins/tilemap/runtime/src/ceramic/TilemapLayerData.hx
+++ b/plugins/tilemap/runtime/src/ceramic/TilemapLayerData.hx
@@ -97,6 +97,16 @@ class TilemapLayerData extends Model {
     @serialize public var tilesAlpha:ReadOnlyArray<Float> = null;
 
     /**
+     * Per-tile x offset in pixels, or null if there is no offset
+     */
+    @serialize public var tilesOffsetX:ReadOnlyArray<Int> = null;
+
+    /**
+     * Per-tile y offset in pixels, or null if there is no offset
+     */
+    @serialize public var tilesOffsetY:ReadOnlyArray<Int> = null;
+
+    /**
      * Computed tiles, after applying auto-tiling (if any).
      * Will be `null` if no auto-tiling is used.
      */
@@ -106,6 +116,16 @@ class TilemapLayerData extends Model {
      * Per-computed tile alpha, or null if there is no custom alpha per computed tile
      */
     @observe public var computedTilesAlpha:ReadOnlyArray<Float> = null;
+
+    /**
+     * Per-computed tile x offset in pixels, or null if there is no offset per computed tile
+     */
+    @observe public var computedTilesOffsetX:ReadOnlyArray<Int> = null;
+
+    /**
+     * Per-computed tile y offset in pixels, or null if there is no offset per computed tile
+     */
+    @observe public var computedTilesOffsetY:ReadOnlyArray<Int> = null;
 
     /**
      * Is `true` if this layer has tiles. Some layers don't have tile and


### PR DESCRIPTION
Pixel coordinates in `gridTiles` and `autoLayerTiles` are not always divisible by `gridWidth` and `gridHeight`. Store this offset when parsing ldtk data and add it to corresponding `TilemapQuad` coordinates.

This change makes these pixel offsets in auto layer rules work in ceramic:
![Screenshot_20231209_180209](https://github.com/ceramic-engine/ceramic/assets/1573047/c45a0d70-2f65-4e33-ab95-e504df41da35)
