### PR TITLE
[ldtk] Fix tile field type name

### DIFF
--- a/plugins/ldtk/runtime/src/ceramic/LdtkData.hx
+++ b/plugins/ldtk/runtime/src/ceramic/LdtkData.hx
@@ -2866,7 +2866,7 @@ class LdtkFieldInstance {
                 return Color.fromString(rawValue);
             case 'Point':
                 return new Point(Std.int(Reflect.field(rawValue, 'cx')), Std.int(Reflect.field(rawValue, 'cy')));
-            case 'TilesetRect':
+            case 'Tile':
                 return new LdtkTilesetRectangle(ldtkData, rawValue);
             case 'EntityRef':
                 return ldtkData != null ? ldtkData._resolveEntityInstance(rawValue, ldtkWorld) : null;


### PR DESCRIPTION
Found this while adding an `Array<Tile>` field to an entity with LDtk 1.5.3.

![Screenshot_20240124_201910](https://github.com/ceramic-engine/ceramic/assets/1573047/b076e604-5964-486c-b9f2-42338aa7e090)

In the [json schema](https://github.com/deepnight/ldtk/blob/e3073565cd92a7d3c5da10e902fb57a25d8789fe/docs/JSON_SCHEMA.json#L497) it says:

> For **Tile**, the value is a TilesetRect object.

Which explains the confusion a little bit. The type string that appears under "__type" is "Tile" while the type name is "TilesetRect".