### PR TITLE
[ldtk] Set layer instance in entity instance

### DIFF
--- a/plugins/ldtk/runtime/src/ceramic/LdtkData.hx
+++ b/plugins/ldtk/runtime/src/ceramic/LdtkData.hx
@@ -3058,7 +3058,7 @@ class LdtkLayerInstance {
 
                 var entityInstancesJson:Array<Dynamic> = json.get('entityInstances');
                 entityInstances = entityInstancesJson != null ? [for (i in 0...entityInstancesJson.length) {
-                    ldtkData._resolveEntityInstance(entityInstancesJson[i], ldtkWorld);
+                    ldtkData._resolveEntityInstance(entityInstancesJson[i], ldtkWorld, this);
                 }] : null;
             }
 


### PR DESCRIPTION
_resolveEntityInstance() has 3 parameters but the last one (ldtkLayerInstance) is never used.
So, when calling createVisualsForEntities(), entities have no layer instance.
I suggest to set ldtkLayerInstance parameter at least in LdtkLayerInstance constructor (useful when createVisualsForEntities is called with a custom createVisual function).