### PR TITLE
Update for Haxe nightlies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ceramic was created by **[Jérémy Faivre](https://github.com/jeremyfa)**, as we
 
 * **[Some GLSL shader code](https://github.com/kiwipxl/GLSL-shaders) by Richman Steward**.
 
-* **[Some browser mess handling](https://github.com/goldfire/howler.js/blob/143ae442386c7b42d91a007d0b1f1695528abe64/src/howler.core.js#L245-L293) from Holwer.js** to help implement Ceramic audio backend for web.
+* **[Some browser mess handling](https://github.com/goldfire/howler.js/blob/143ae442386c7b42d91a007d0b1f1695528abe64/src/howler.core.js#L245-L293) from Howler.js** to help implement Ceramic audio backend for web.
 
 * **[Heaps Aseprite](https://github.com/AustinEast/heaps-aseprite) by Austin East**, from which several snippets were ported for make Ceramic `ase` format parsing and rendering.
 

--- a/runtime/src/ceramic/macros/ComponentMacro.hx
+++ b/runtime/src/ceramic/macros/ComponentMacro.hx
@@ -272,7 +272,7 @@ class ComponentMacro {
         #if (!display && !completion)
         for (entityField in entityFields) {
             var entityFieldName = entityField.name;
-            var entityType:haxe.macro.ComplexType = null;
+            var entityType:ComplexType = null;
             switch entityField.kind {
                 default:
                 case FVar(t, e):

--- a/runtime/src/ceramic/macros/StateMachineMacro.hx
+++ b/runtime/src/ceramic/macros/StateMachineMacro.hx
@@ -8,7 +8,7 @@ using haxe.macro.ExprTools;
 
 class StateMachineMacro {
 
-    @:persistent static var stateTypeByImplName:Map<String,haxe.macro.ComplexType> = null;
+    @:persistent static var stateTypeByImplName:Map<String,ComplexType> = null;
 
     static var usedNames:Map<String,Bool> = null;
 
@@ -182,7 +182,7 @@ class StateMachineMacro {
 
     }
 
-    static function sanitizeComplexType(complexType:haxe.macro.ComplexType) {
+    static function sanitizeComplexType(complexType:ComplexType) {
 
         if (complexType == null)
             return null;
@@ -895,7 +895,7 @@ class StateMachineMacro {
 
     }
 
-    public static function getStateTypeFromImplName(implName:String):haxe.macro.ComplexType {
+    public static function getStateTypeFromImplName(implName:String):ComplexType {
 
         if (stateTypeByImplName == null)
             return null;


### PR DESCRIPTION
Support for using subtypes with `pack.to.Subtype` instead of `pack.to.Module.Subtype` has been removed in HaxeFoundation/Haxe#11338

Since `haxe.macro.Expr` is imported there, just removing the path is enough.
Note: I'm not 100% sure those are the only occurrences, as I tested with haxelib ceramic on a simple project, so there might be more recent occurrences and/or code path I'm not using that have the same issue.