### PR TITLE
Open links in default browser

### DIFF
--- a/runner/app.js
+++ b/runner/app.js
@@ -178,6 +178,12 @@ function createWindow() {
     // Open the DevTools.
     //mainWindow.webContents.openDevTools()
 
+    // Open links in the OS default browser (deprecated in electron 22, use setOpenWindowHandler())
+    mainWindow.webContents.on('new-window', function(e, url) {
+	   e.preventDefault();
+	   electron.shell.openExternal(url);
+    });
+
     // Emitted when the window is closed.
     mainWindow.on('closed', function() {
         // Dereference the window object, usually you would store windows

--- a/runner/app.js
+++ b/runner/app.js
@@ -178,10 +178,10 @@ function createWindow() {
     // Open the DevTools.
     //mainWindow.webContents.openDevTools()
 
-    // Open links in the OS default browser (deprecated in electron 22, use setOpenWindowHandler())
-    mainWindow.webContents.on('new-window', function(e, url) {
-	   e.preventDefault();
-	   electron.shell.openExternal(url);
+    // Open links in the OS default browser
+    mainWindow.webContents.setWindowOpenHandler(( { url }) => {
+	electron.shell.openExternal(url);
+	return { action : 'deny' };
     });
 
     // Emitted when the window is closed.


### PR DESCRIPTION
Currently, opening links in a web build creates new electron windows instead of using the default browser. This opens them in the browser.

The solution is deprecated in Electron 22 and requires new API that isn't available on the current version of Electron, so it'll have to be changed or ifdef'd eventually.

Not familiar with js, let me know any feedback.