### PR TITLE
[ase] Fix out-of-bounds write in `AsepriteParser`

### DIFF
--- a/plugins/ase/runtime/src/ceramic/AsepriteParser.hx
+++ b/plugins/ase/runtime/src/ceramic/AsepriteParser.hx
@@ -438,21 +438,36 @@ class AsepriteParser {
                     var relY:Int = frameCelChunk.yPosition - top;
                     var celW:Int = frameCelChunk.width;
                     var celH:Int = frameCelChunk.height;
+
+                    // Trim left
                     if (relX < 0) {
                         srcX -= relX;
                         celW += relX;
                         relX = 0;
                     }
+
+                    // Trim top
                     if (relY < 0) {
                         srcY -= relY;
                         celH += relY;
                         relY = 0;
                     }
+
+                    // Trim right
+                    if (relX + celW > packedWidth) {
+                        celW = packedWidth - relX;
+                    }
+
+                    // Trim bottom
+                    if (relY + celH > packedHeight) {
+                        celH = packedHeight - relY;
+                    }
+
                     if (celW > 0 && celH > 0) {
                         blendAseFrameLayerPixels(
                             frameLayer.pixels, frameCelChunk.width,
                             frame.pixels, packedWidth,
-                            0, 0, celW, celH,
+                            srcX, srcY, celW, celH,
                             relX, relY, frameLayer.layer.blendMode, frameLayer.layer.opacity
                         );
                     }


### PR DESCRIPTION
This is something I've stumbled upon a while ago, but I have not come up with a better solution since then ¯\\\_(ツ)\_/¯

This PR makes sure that the size of `celW`x`celH` is not larger than one of the destination buffer `frame.pixels`.