### PR TITLE
Fix randomElement()

### DIFF
--- a/runtime/src/ceramic/Extensions.hx
+++ b/runtime/src/ceramic/Extensions.hx
@@ -163,7 +163,7 @@ class Extensions<T> {
      */
     inline public static function randomElement<T>(array:Array<T>):T {
 
-        return array[Math.floor(Math.random() * 0.99999 * array.length)];
+        return array[Math.floor(Math.random() * array.length)];
 
     }
 
@@ -250,7 +250,7 @@ class Extensions<T> {
      * trace(deck); // e.g., [3, 1, 5, 2, 4]
      * ```
      * 
-     * @see https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+     * @see https://en.wikipedia.org/wiki/Fisher–Yates_shuffle
      */
     public static function shuffle<T>(arr:Array<T>):Void
     {


### PR DESCRIPTION
With `0.99999` the last element of 100_000 len array is never chosen.

Test code - https://try.haxe.org/#99b0199D

```haxe
class Test {
	static function main() {
		testNineKoef();
	}

	inline static function randIndex(len:Int):Int {
		return Math.floor(Math.random() * 0.99999 * len);
	}

	inline static function randIndexCorrect(len:Int):Int {
		return Math.floor(Math.random() * len);
	}

	static function testNineKoef() {
		var len = 100_000;
		var data:Array<Int> = [for (i in 0...len) 0];

		for (i in 0...50_000_000) {
			var index = randIndex(len);
			data[index] += 1;
		}
		trace('\nLast element, should not be zero, but it is: ${data[len - 1]}');
		trace('\nslice of 10 last elements:\n${data.slice(len - 10)}');

		// correct one
		data = [for (i in 0...len) 0];
		for (i in 0...50_000_000) {
			var index = randIndexCorrect(len);
			data[index] += 1;
		}
		trace('\nLast element, should not be zero, and it is: ${data[len - 1]}');
		trace('\nslice of 10 last elements:\n${data.slice(len - 10)}');
	}
}
```
```
15:10:34:097   Test.hx:22:, Last element, should not be zero, but it is: 0
15:10:34:097   Test.hx:23:, slice of 10 last elements: [519,489,502,529,480,513,534,518,523,0]
15:10:34:309   Test.hx:31:, Last element, should not be zero, and it is: 486
15:10:34:309   Test.hx:32:, slice of 10 last elements: [510,539,458,500,506,497,494,479,485,486]
```

There are other `0.99999` in the code but I am not sure they are related.


