### PR TITLE
add full revolution support for VisualTransition

### DIFF
--- a/runtime/src/ceramic/VisualTransition.hx
+++ b/runtime/src/ceramic/VisualTransition.hx
@@ -48,6 +48,7 @@ using ceramic.Extensions;
  * - Size: width, height, size()
  * - Scale: scaleX, scaleY, scale()
  * - Rotation: rotation (with shortest path)
+ * - Revolution: rotation that supports full 360 degrees revolution
  * - Transform: transform, translateX/Y, skewX/Y
  * - Appearance: alpha, color
  * - Anchor: anchorX, anchorY, anchor()
@@ -192,6 +193,8 @@ class VisualTransition extends Entity implements Component {
 
     /** Flag indicating if the rotation was modified in the current transition. */
     var rotationChanged:Bool = false;
+    /** Flag indicating if the revolution (non-clamped rotation) was modified in the current transition. */
+    var revolutionChanged:Bool = false;
     /** Active tween responsible for animating the rotation. */
     var rotationTween:Tween = null;
     /** Target rotation value in degrees to animate towards. */
@@ -416,6 +419,7 @@ class VisualTransition extends Entity implements Component {
         anchorXChanged = false;
         anchorYChanged = false;
         rotationChanged = false;
+        revolutionChanged = false;
         widthChanged = false;
         heightChanged = false;
         colorChanged = false;
@@ -649,6 +653,13 @@ class VisualTransition extends Entity implements Component {
                     viewHeightTween = null;
                 #end
             });
+            propsTween.onComplete(this, () -> {
+                if (revolutionChanged)
+                // To prevent accumulation of rotation it must be clamped
+                // when the tween completes.
+                // NOTE: debatable, user can expect values like 720
+                    entity.rotation = GeometryUtils.clampDegrees(entity.rotation);
+            });
 
             if (xChanged) {
                 xTween = propsTween;
@@ -705,7 +716,11 @@ class VisualTransition extends Entity implements Component {
                 anchorYStart = anchorYCurrent;
                 anchorYEnd = anchorYTarget;
             }
-            if (rotationChanged) {
+            if (revolutionChanged) {
+                rotationTween = propsTween;
+                rotationStart = GeometryUtils.clampDegrees(rotationCurrent);
+                rotationEnd = rotationTarget;
+            } else if (rotationChanged) {
                 rotationTween = propsTween;
                 rotationStart = GeometryUtils.clampDegrees(rotationCurrent);
                 rotationEnd = GeometryUtils.clampDegrees(rotationTarget);
@@ -1119,6 +1134,24 @@ abstract VisualTransitionProperties(VisualTransition) from VisualTransition {
         if (this.rotationTween == null || rotation != this.rotationEnd) {
             this.anyPropertyChanged = true;
             this.rotationChanged = true;
+            this.revolutionChanged = false;
+        }
+        this.rotationTarget = rotation;
+        return rotation;
+    }
+
+    /**
+     * Target rotation in degrees.
+     * Does not use shortest path interpolation.
+     * Allows to animate full revolutions (e.g. 720 degrees as 2 full revolutions)
+     */
+    public var revolution(get, set):Float;
+    function get_revolution():Float return this.rotationTarget;
+    function set_revolution(rotation:Float):Float {
+        if (this.rotationTween == null || rotation != this.rotationEnd) {
+            this.anyPropertyChanged = true;
+            this.rotationChanged = false;
+            this.revolutionChanged = true;
         }
         this.rotationTarget = rotation;
         return rotation;


### PR DESCRIPTION
- tween now supports rotations like 720 degrees (2 revolutions)
- new option, old way is intact

Comparison:

<img width="640" height="480" alt="sdfsdfsd" src="https://github.com/user-attachments/assets/ce86e5f9-3f40-4234-8808-2e4243aa8a3d" />

Example scene

<details>

```haxe
import ceramic.Text;
import ceramic.Visual;
import ceramic.Timer;
import ceramic.Quad;
import ceramic.Color;
import ceramic.Scene;

class RevolutionScene extends Scene {

	var v1:Visual;
	var v2:Visual;
	var visualRotation = 210.0;

	override function create() {
		super.create();

		v1 = buildVisual(app.screen.width * 0.33, app.screen.height*0.5, Color.CRIMSON, 'Rotation');
		v2 = buildVisual(app.screen.width * 0.66, app.screen.height*0.5, Color.CYAN, 'Revolution');

		tweenRotation();
		tweenRevolution();

		add(v1);
		add(v2);
	}

	function tweenRotation() {
		v1.transition(QUAD_EASE_IN_OUT, 2.0, props -> {
			props.rotation = v1.rotation + visualRotation;
		}).onComplete(this, () -> Timer.delay(this, 0.5, tweenRotation));
	}

	function tweenRevolution() {
		v2.transition(QUAD_EASE_IN_OUT, 2.0, props -> {
			props.revolution = v2.rotation + visualRotation;
		}).onComplete(this, () -> Timer.delay(this, 0.5, tweenRevolution));
	}

	function buildVisual(x:Float, y:Float, color:Color, text = 'hello'):Visual {
		var t = new Text();
		t.color = color;
		t.content = text;
		t.pointSize = 32;
		t.pos(x,y);
		t.anchor(0.5,0.5);
		return t;
	}
}
```
</details>